### PR TITLE
Fix TypeError

### DIFF
--- a/src/Logger/Sentry.php
+++ b/src/Logger/Sentry.php
@@ -177,7 +177,7 @@ class Sentry implements LoggerInterface
     protected function getUserData(array $context): array
     {
         $data = [
-            'id' => $context['uid'] ?? '0',
+            'id' => (int) ($context['uid'] ?? '0'),
             'ip_address' => $context['ip'],
         ];
 

--- a/src/Logger/Sentry.php
+++ b/src/Logger/Sentry.php
@@ -177,7 +177,7 @@ class Sentry implements LoggerInterface
     protected function getUserData(array $context): array
     {
         $data = [
-            'id' => (int) ($context['uid'] ?? '0'),
+            'id' => (string) ($context['uid'] ?? '0'),
             'ip_address' => $context['ip'],
         ];
 


### PR DESCRIPTION
Fixes:

```
Failed to log error: TypeError: Return value of Sentry\Context\UserContext::getId() must be of the type string or null, integer returned in Sentry\Context\UserContext->getId() (line 20 of /app/vendor/sentry/sentry/src/Context/UserContext.php).
#0 /app/public/modules/contrib/wmsentry/src/EventSubscriber/ExcludedTagsSubscriber.php(64): Sentry\Context\UserContext->getId()
#1 /app/public/modules/contrib/wmsentry/src/EventSubscriber/ExcludedTagsSubscriber.php(37): Drupal\wmsentry\EventSubscriber\ExcludedTagsSubscriber->getAllTags(Object(Sentry\Event))
```