### PR TITLE
Require Drupal 9.1 and PHP 8.0

### DIFF
--- a/.php_cs.php
+++ b/.php_cs.php
@@ -1,9 +1,9 @@
 <?php
 
 use Wieni\wmcodestyle\PhpCsFixer\Config\Factory;
-use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php71;
+use Wieni\wmcodestyle\PhpCsFixer\Config\RuleSet\Php80;
 
-$config = Factory::fromRuleSet(new Php71);
+$config = Factory::fromRuleSet(new Php80);
 
 $config->getFinder()
     ->ignoreVCSIgnored(true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2021-08-24
+### Fixed
+- Fix Drupal 9.1 Event dispatching deprecations (https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407) 
+
 ## [1.7.5] - 2021-06-20
 ### Fixed
 - Update error handler

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ wmsentry
 [![Total Downloads](https://poser.pugx.org/wieni/wmsentry/downloads)](https://packagist.org/packages/wieni/wmsentry)
 [![License](https://poser.pugx.org/wieni/wmsentry/license)](https://packagist.org/packages/wieni/wmsentry)
 
-> A module for sending errors to Sentry in Drupal 8.
+> A module for sending errors to Sentry in Drupal 9.
 
 ## Why?
 - We use [Sentry](https://sentry.io) to monitor our sites and to track
@@ -14,7 +14,7 @@ wmsentry
   with Drupal, using v2 of the Sentry SDK.
 
 ## Installation
-This module requires PHP 7.2 or higher and uses the Sentry PHP package
+This module requires PHP 8.0 or higher and uses the Sentry PHP package
 ([`sentry/sentry`](https://github.com/getsentry/sentry-php)), which is
 not tied to any specific library that sends HTTP messages. Instead, it
 uses [Httplug](https://github.com/php-http/httplug) to let users choose

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "wieni/wmsentry",
     "type": "drupal-module",
-    "description": "A module for sending errors to Sentry in Drupal 8.",
+    "description": "A module for sending errors to Sentry in Drupal 9.",
     "license": "MIT",
     "authors": [
         {
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "drupal/core": "^9.1",
         "sentry/sentry": "^3.1.1"
     },
     "require-dev": {
         "composer-runtime-api": "^2.0",
         "ergebnis/composer-normalize": "^2.0",
-        "wieni/wmcodestyle": "^1.3"
+        "wieni/wmcodestyle": "^1.7"
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "drupal/core": "^8.0 || ^9.0",
+        "drupal/core": "^9.1",
         "sentry/sentry": "^3.1.1"
     },
     "require-dev": {

--- a/src/Event/SentryBeforeBreadcrumbEvent.php
+++ b/src/Event/SentryBeforeBreadcrumbEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmsentry\Event;
 
 use Sentry\Breadcrumb;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class SentryBeforeBreadcrumbEvent extends Event
 {

--- a/src/Event/SentryBeforeSendEvent.php
+++ b/src/Event/SentryBeforeSendEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmsentry\Event;
 
 use Sentry\Event;
-use Symfony\Component\EventDispatcher\Event as EventBase;
+use Drupal\Component\EventDispatcher\Event as EventBase;
 
 class SentryBeforeSendEvent extends EventBase
 {

--- a/src/Event/SentryOptionsAlterEvent.php
+++ b/src/Event/SentryOptionsAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmsentry\Event;
 
 use Sentry\Options;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class SentryOptionsAlterEvent extends Event
 {

--- a/src/Event/SentryScopeAlterEvent.php
+++ b/src/Event/SentryScopeAlterEvent.php
@@ -3,7 +3,7 @@
 namespace Drupal\wmsentry\Event;
 
 use Sentry\State\Scope;
-use Symfony\Component\EventDispatcher\Event;
+use Drupal\Component\EventDispatcher\Event;
 
 class SentryScopeAlterEvent extends Event
 {

--- a/src/Logger/Sentry.php
+++ b/src/Logger/Sentry.php
@@ -105,8 +105,8 @@ class Sentry implements LoggerInterface
     {
         /** @var SentryBeforeSendEvent $beforeSendEvent */
         $beforeSendEvent = $this->eventDispatcher->dispatch(
-            WmsentryEvents::BEFORE_SEND,
-            new SentryBeforeSendEvent($event)
+            new SentryBeforeSendEvent($event),
+            WmsentryEvents::BEFORE_SEND
         );
 
         return $beforeSendEvent->isExcluded() ? null : $beforeSendEvent->getEvent();
@@ -116,8 +116,8 @@ class Sentry implements LoggerInterface
     {
         /** @var SentryBeforeBreadcrumbEvent $beforeBreadcrumbEvent */
         $beforeBreadcrumbEvent = $this->eventDispatcher->dispatch(
-            WmsentryEvents::BEFORE_BREADCRUMB,
-            new SentryBeforeBreadcrumbEvent($breadcrumb)
+            new SentryBeforeBreadcrumbEvent($breadcrumb),
+            WmsentryEvents::BEFORE_BREADCRUMB
         );
 
         return $beforeBreadcrumbEvent->isExcluded() ? null : $beforeBreadcrumbEvent->getBreadcrumb();
@@ -201,8 +201,8 @@ class Sentry implements LoggerInterface
 
         withScope(function (Scope $scope) use ($event, $eventHint, $context): void {
             $this->eventDispatcher->dispatch(
-                WmsentryEvents::SCOPE_ALTER,
-                new SentryScopeAlterEvent($scope, $context)
+                new SentryScopeAlterEvent($scope, $context),
+                WmsentryEvents::SCOPE_ALTER
             );
 
             captureEvent($event, $eventHint);
@@ -240,8 +240,8 @@ class Sentry implements LoggerInterface
         }
 
         $this->eventDispatcher->dispatch(
-            WmsentryEvents::OPTIONS_ALTER,
-            new SentryOptionsAlterEvent($options)
+            new SentryOptionsAlterEvent($options),
+            WmsentryEvents::OPTIONS_ALTER
         );
 
         return $this->client = (new ClientBuilder($options))->getClient();


### PR DESCRIPTION
Some deprecations are being thrown now and its a pain to provide a backwards compatible solution.

See https://www.drupal.org/node/3159012 and https://www.drupal.org/node/3154407

This MR will bump the composer requirement to Drupal 9.1 and PHP 8.0