### PR TITLE
Symfony 6+ compatibility: Response::create() removal + lost $context in logException()

### DIFF
--- a/src/Controller/SetReleaseController.php
+++ b/src/Controller/SetReleaseController.php
@@ -74,11 +74,11 @@ class SetReleaseController implements ContainerInjectionInterface
         try {
             $destination = $this->destination->get();
             $url = Url::fromUserInput($destination)->setAbsolute()->toString();
-            return RedirectResponse::create($url);
+            return new RedirectResponse($url);
         } catch (\InvalidArgumentException $e) {
         }
 
-        return Response::create();
+        return new Response();
     }
 
     protected function isValidToken(?string $token, ?int $timestamp): bool

--- a/src/Logger/Sentry.php
+++ b/src/Logger/Sentry.php
@@ -174,7 +174,7 @@ class Sentry implements LoggerInterface
 
         $event->setExtra(array_reduce(
             ['link', 'referer', 'request_uri'],
-            static function (array $tags, string $key) {
+            static function (array $tags, string $key) use ($context) {
                 if (isset($context[$key])) {
                     $tags[$key] = $context[$key];
                 }


### PR DESCRIPTION
## Summary
- **`SetReleaseController::unset()`**: `RedirectResponse::create()` / `Response::create()` were **removed in Symfony 6** — this code path fatals on Drupal 10.2+ today. Replaced with `new RedirectResponse(...)` / `new Response(...)` preserving arguments.
- **`Sentry::logException()`**: the `array_reduce` closure building the event `extra` payload never captured `$context` (undefined variable; the sibling closure right above captures it correctly) — added `use ($context)`. Unambiguous copy-paste bug; exception log entries now actually carry their context extras.

---
Found by a `drupal/upgrade_status` 5.x scan on Drupal 11.4 (intranet.uzleuven.be upgrade); every finding was re-verified against `main` HEAD before fixing, and the pushed diff was independently re-reviewed (lint, semantics, scope, no unrelated changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EeazvHFUoYTXZGXAN5SZc
